### PR TITLE
Апдейт контрабанды и печать тритора

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -79,6 +79,8 @@
 /proc/is_turf_no_mines_and_walls(var/turf/T)
 	if(!istype(T, /turf/simulated/floor))
 		return FALSE
+	if(istype(T, /turf/simulated/floor/reinforced))
+		return FALSE
 	if(locate(/obj/item/mine) in T)
 		return FALSE
 	return TRUE

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -78,3 +78,9 @@
 	great for stashing your stolen goods. Comes with a crowbar and a floor tile."
 	item_cost = 20
 	path = /obj/item/storage/backpack/satchel/flat
+
+/datum/uplink_item/item/stealth_items/chameleon_stamp //BoS
+	name = "Chameleon Stamp"
+	desc = "Captain, kill yourself now! It Buker order, documents with stamp here."
+	item_cost = 20
+	path = /obj/item/stamp/chameleon

--- a/code/modules/aspects/contraband.dm
+++ b/code/modules/aspects/contraband.dm
@@ -5,7 +5,7 @@
 	name = "Контрабанда"
 	chance = 15
 	weight = ASPECT_WEIGHT_CONTRABAND
-	announce_text = "<span class=\"warning\">Недавно была получена информация о большом схроне контрабанды на Антарес - но на месте ничего не нашли. Вероятно контрабандисты всё уже перепрятали, но делали они это, наверняка, в спешке...</span>"
+	announce_text = "<span class=\"info\">Недавно была получена информация о большом схроне контрабанды на Антарес - но на месте ничего не нашли. Вероятно контрабандисты всё уже перепрятали, но делали они это, наверняка, в спешке...</span>"
 
 /datum/round_aspect/contraband/get_desc_msg()
 	return SPAN_WARNING("Тоннели стали более интересными...")
@@ -17,9 +17,12 @@
 	var/list/turf/avalible_turfs = get_subarea_turfs(maintarea, list(/proc/is_turf_no_mines_and_walls))
 	for(var/j in 1 to rand(CONTR_MIN, CONTR_MAX))
 		T = pick(avalible_turfs)
-		new /obj/random/contraband (T)
-		if(prob(20))
-			new /obj/random/lilgun (T)
+		if(prob(97))
+			var/contraband_common = pick(/obj/random/lilgun, /obj/random/contraband, /obj/random/contraband, /obj/random/contraband)
+			new contraband_common (T)
+		else
+			var/contraband_rare = pick(/obj/item/device/personal_shield, /obj/item/device/multitool/hacktool, /obj/item/stamp/chameleon, /obj/item/device/radio/uplink, /obj/item/device/encryptionkey/syndicate, /obj/item/device/chameleon, /obj/item/card/emag, /obj/item/storage/box/syndie_kit/toxin, /obj/item/storage/box/syndie_kit/spy, /obj/item/device/uplink_service/fake_command_report, /obj/item/storage/pill_bottle/three_eye, /obj/item/grenade/spawnergrenade/spesscarp, /obj/item/grenade/frag, /obj/item/storage/backpack/dufflebag/syndie/c4, /obj/item/clothing/mask/chameleon/voice, /obj/item/supply_beacon, /obj/item/device/flashlight/flashdark)
+			new contraband_rare (T)
 
 #undef CONTR_MIN
 #undef CONTR_MAX


### PR DESCRIPTION
В аплинк добавлена печать хамелеон, которая может подделывать почти все печати(в том числе есть печать флота ЛСС) кроме печати с факса
Аспект контрабанды стал смешнее, теперь спавнятся не только ножи и пушки, но и в малом количестве всякие вещи из аплинка, гранаты, триглаз, а может и сам аплинк
А ещё к проку что используется аспектом мин и контрабандой добавлен костыль, который не позволяет весёлым штукам спавниться на обшивке
Проверено на локалке