### PR TITLE
Исправление у труб в чекпоинте рядом мемориалом

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -9818,8 +9818,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "we" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -9833,13 +9835,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "wg" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "wi" = (
@@ -46141,7 +46141,7 @@ tc
 Pa
 uG
 vq
-if
+mp
 Qn
 if
 if

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -20173,7 +20173,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralport)
 "iPb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -25568,6 +25567,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
+"pmb" = (
+/obj/structure/bed/chair/office/comfy/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/secpointhal)
 "pmz" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -26675,19 +26687,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
-"qyb" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
 "qyX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/clothing/suit/armor/laserproof{
@@ -27249,12 +27248,6 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
-"qYb" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
 "qYy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -27768,6 +27761,12 @@
 /obj/item/armorchargebattery,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
+"rzb" = (
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/secpointhal)
 "rAb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
@@ -53096,7 +53095,7 @@ jGb
 sbh
 bta
 qFb
-qyb
+pmb
 sbh
 jfb
 rQb
@@ -53296,10 +53295,10 @@ jzb
 mav
 pHb
 pZb
-qYb
-qYb
-qYb
-qYb
+rzb
+rzb
+rzb
+rzb
 sbb
 ssb
 sdb

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -14718,8 +14718,15 @@
 /obj/structure/bed/chair/office/comfy/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "btb" = (
@@ -20438,6 +20445,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "jfn" = (
@@ -20804,6 +20816,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "jzb" = (
@@ -20942,6 +20959,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "jHb" = (
@@ -21160,16 +21182,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
@@ -25546,16 +25568,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
-"pmb" = (
-/obj/structure/bed/chair/office/comfy/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
 "pmz" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
@@ -26119,6 +26131,11 @@
 /obj/effect/floor_decal/corner/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "pWc" = (
@@ -26658,6 +26675,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
+"qyb" = (
+/obj/structure/bed/chair/office/comfy/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/secpointhal)
 "qyX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/clothing/suit/armor/laserproof{
@@ -26788,6 +26818,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
@@ -28265,11 +28300,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "sbh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "sbJ" = (
@@ -53049,9 +53094,9 @@ jyb
 pWb
 jGb
 sbh
-pmb
-qFb
 bta
+qFb
+qyb
 sbh
 jfb
 rQb

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -12895,13 +12895,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
-"aSK" = (
-/obj/machinery/button/blast_door{
-	id_tag = "gift_shut";
-	name = "shutters control"
-	},
-/turf/simulated/wall/r_wall/prepainted,
-/area/security/secpointhal)
 "aSS" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -14725,6 +14718,8 @@
 /obj/structure/bed/chair/office/comfy/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "btb" = (
@@ -18923,11 +18918,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Research Equipment";
-	sort_type = "Research Equipment"
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -18950,6 +18940,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/firstdeck/aft)
@@ -19156,7 +19149,6 @@
 /area/security/brig/perma)
 "hub" = (
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19360,7 +19352,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/infirmreception)
 "hFb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
@@ -19432,7 +19423,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/cap/visible/scrubbers,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "hKb" = (
@@ -20274,7 +20265,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
 "iVb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -20419,7 +20409,6 @@
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "jeb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -20443,6 +20432,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/rnd/anom_storage/living)
 "jfb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "jfn" = (
@@ -20797,30 +20792,31 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
 "jyb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
-"jzb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
+/turf/simulated/floor/tiled/dark,
+/area/security/secpointhal)
+"jzb" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/glass/security{
 	dir = 4
@@ -20944,6 +20940,8 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "jHb" = (
@@ -21168,6 +21166,11 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "jXp" = (
@@ -22459,9 +22462,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -22471,7 +22471,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/security/secpointhal)
+/area/mempark)
 "lAp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -22495,10 +22495,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "lBb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -24324,7 +24320,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/opscheck)
 "nRb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24537,7 +24532,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "obb" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
 	d1 = 2;
@@ -25553,15 +25547,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "pmb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair/office/comfy/red{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/r_wall/prepainted,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "pmz" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -25889,14 +25882,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/gunnery/mim)
 "pHb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 8
 	},
@@ -26132,6 +26117,8 @@
 /area/security/detectives_office)
 "pWb" = (
 /obj/effect/floor_decal/corner/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "pWc" = (
@@ -26173,17 +26160,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/security/range)
 "pZb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -26552,6 +26528,9 @@
 	dir = 9
 	},
 /obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "qrb" = (
@@ -26679,19 +26658,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
-"qyb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
 "qyX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/clothing/suit/armor/laserproof{
@@ -26819,7 +26785,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "qFb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -26870,6 +26837,11 @@
 "qHb" = (
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "gift_shut";
+	name = "giftshop's shutters control";
+	pixel_x = -24
 	},
 /turf/simulated/floor/tiled,
 /area/mempark/gift)
@@ -27243,15 +27215,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
 "qYb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
@@ -27770,19 +27733,6 @@
 /obj/item/armorchargebattery,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
-"rzb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
 "rAb" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
@@ -28018,19 +27968,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/mempark)
-"rMb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secpointhal)
 "rNb" = (
 /obj/machinery/light{
 	dir = 8;
@@ -28316,26 +28253,23 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
 "sbb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "sbh" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/security/secpointhal)
 "sbJ" = (
@@ -53115,10 +53049,10 @@ jyb
 pWb
 jGb
 sbh
-bta
+pmb
 qFb
 bta
-jfb
+sbh
 jfb
 rQb
 mav
@@ -53314,13 +53248,13 @@ ijb
 ijb
 rAb
 jzb
-pmb
+mav
 pHb
 pZb
-qyb
 qYb
-rzb
-rMb
+qYb
+qYb
+qYb
 sbb
 ssb
 sdb
@@ -53517,7 +53451,7 @@ nDB
 bOZ
 lAb
 mav
-aSK
+mav
 mav
 mav
 mav


### PR DESCRIPTION
# Изменения

* Убрана вторая мусорка из чекпоинта возле мемориала
* Убрано ответвление труб к второй мусорке
* Убран сортировщик с тегом `reserch equipment` из коридора
* Убраны трубы из-под стены чекпоинта
* Добавлено по одному выходу вентиляции и скрубберу в чекпоинте
* Перемещена кнопка из стены между чекпоинтом и магазином сувениров в область магазина
* Убран одинокий тайл зоны мемориала из магазина сувениров (это должно чуть-чуть улучшить результаты тесты)
* В реакторе на суперматерии добавлен насос на контур зелёных труб возле радиатора для циркуляции газа